### PR TITLE
Make Cache-Control Header Configurable

### DIFF
--- a/bin/deploy-web-to-s3.js
+++ b/bin/deploy-web-to-s3.js
@@ -32,8 +32,6 @@ if(process.env.AWS_EXCLUDE) {
 	exclude = process.env.AWS_EXCLUDE.split(',')
 }
 
-var _30_DAYS_IN_SECONDS = 30 * 24 * 3600;
-
 deployer({
 	aws: {
 		bucket: process.env.AWS_BUCKET,
@@ -46,7 +44,7 @@ deployer({
 	versionPrefix: process.env.AWS_VERSION_PREFIX || null,
 	gzipExtensions: gzipExtensions,
 	exclude,
-	cacheControl: process.env.AWS_CACHE_CONTROL || _30_DAYS_IN_SECONDS,
+	cacheControl: process.env.AWS_CACHE_CONTROL,
 });
 
 function exit(msg) {

--- a/bin/deploy-web-to-s3.js
+++ b/bin/deploy-web-to-s3.js
@@ -32,6 +32,8 @@ if(process.env.AWS_EXCLUDE) {
 	exclude = process.env.AWS_EXCLUDE.split(',')
 }
 
+var _30_DAYS_IN_SECONDS = 30 * 24 * 3600;
+
 deployer({
 	aws: {
 		bucket: process.env.AWS_BUCKET,
@@ -44,6 +46,7 @@ deployer({
 	versionPrefix: process.env.AWS_VERSION_PREFIX || null,
 	gzipExtensions: gzipExtensions,
 	exclude,
+	cacheControl: process.env.AWS_CACHE_CONTROL || _30_DAYS_IN_SECONDS,
 });
 
 function exit(msg) {

--- a/index.js
+++ b/index.js
@@ -44,12 +44,14 @@ module.exports = function(options) {
 		addVersionJSON(versionPromise, options.buildFolder),
 	])
 		.then(function() {
+			var _30_DAYS_IN_SECONDS = 30 * 24 * 3600;
+
 			return uploader(options.buildFolder, {
 				pathPrefix: bucketUrl,
 				getHeadersForFile: getHeadersForFile,
 				gzipExtensions: options.gzipExtensions,
 				exclude: options.exclude,
-				cacheControl: options.cacheControl,
+				cacheControl: options.cacheControl || _30_DAYS_IN_SECONDS,
 			});
 		})
 		.catch(function(err) {

--- a/index.js
+++ b/index.js
@@ -49,6 +49,7 @@ module.exports = function(options) {
 				getHeadersForFile: getHeadersForFile,
 				gzipExtensions: options.gzipExtensions,
 				exclude: options.exclude,
+				cacheControl: options.cacheControl,
 			});
 		})
 		.catch(function(err) {

--- a/readme.md
+++ b/readme.md
@@ -80,7 +80,7 @@ A static prefix to add before the version. It is only used if
 A list of file extensions that should be gzipped before uploaded to S3.
 Gzipped files will have their `content-encoding` set to `gzip` when served.
 *Note: This also means that user agents that does not support the `gzip` content
-encoding will not be able to receive this file as S3 doesn't support automatic 
+encoding will not be able to receive this file as S3 doesn't support automatic
 content negotiation.*
 
 	export AWS_GZIP_EXTENSIONS=.js,.css
@@ -96,3 +96,14 @@ matched based on the `<folder to upload>`.
 	# contains the words ['node_modules','upload-script']
 	export AWS_EXCLUDE=node_modules,upload-script
 	deploy-web-to-s3 <folder to upload>
+
+
+### AWS_CACHE_CONTROL
+
+Use the Cache-Control header to control how long objects stay in the cache.
+Units are in number of seconds. To cache a file for 24 hours, you would use
+the `AWS_CACHE_CONTROL=86400` environment variable. The resulting headers
+would look like this: `Cache-Control: max-age=86400`. If no AWS_CACHE_CONTROL
+is provided, `Cache-Control` will default to 30 days.
+
+export AWS_CACHE_CONTROL=seconds

--- a/upload-folder-to-s3.js
+++ b/upload-folder-to-s3.js
@@ -9,8 +9,6 @@ var mime = require('mime-types')
 
 var normalizeHeaders = require('./normalize-headers')
 
-var _30daysInSeconds = 30 * 24 * 3600
-
 module.exports = function(bucket, accessKey, secretKey, instanceOptions) {
 	var url = 'https://' + bucket + '.s3.amazonaws.com/'
 
@@ -85,11 +83,12 @@ module.exports = function(bucket, accessKey, secretKey, instanceOptions) {
 			return Promise.all(fileObjects.map(function(fileObject) {
 				var userHeaders = options.getHeadersForFile && options.getHeadersForFile(fileObject.filename)
 				var localPath = fileObject.localPath
+				var cacheControl = options.cacheControl
 				return stat(localPath)
 					.then(function(stat) {
 						var statHeaders = {
 							'content-length': stat.size,
-							'cache-control': 'max-age=' + _30daysInSeconds,
+							'cache-control': 'max-age=' + cacheControl,
 						}
 
 						var headers = fmerge(normalizeHeaders(statHeaders), normalizeHeaders(fileObject.headers), normalizeHeaders(userHeaders))


### PR DESCRIPTION
Hi @fizker and @revisohq Team!

This PR exposes the S3 file Cache-Control header as a configurable environment variable called `AWS_CACHE_CONTROL`. So if we wanted a 90 day cache instead of the default 30 day cache, we could run:

```
AWS_CACHE_CONTROL=7776000 deploy-web-to-s3 src/some-file.js
```

Looks good?

We're using `deploy-web-to-s3` on CircleCI to deploy some SDK assets to S3. It's worked perfectly so far, so just wanted to also take some time to say Thank You! 
